### PR TITLE
Fix GitHub Pages base path for Vite build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,8 +1,7 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-// Update `base` to `/<your-repo-name>/` before pushing to GitHub Pages.
 export default defineConfig({
   plugins: [react()],
-  base: '/bradyash.github.io/' // CHANGE if your repo name is different
+  base: '/'
 })


### PR DESCRIPTION
## Summary
- set the Vite `base` path to root so assets resolve correctly on the username.github.io deployment

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2df572b20832f987d69ff72dfa08f